### PR TITLE
Update `pre > code` to pre-wrap in skeleton.css

### DIFF
--- a/static/skeleton.css
+++ b/static/skeleton.css
@@ -317,7 +317,7 @@ code {
 pre > code {
   display: block;
   padding: 1rem 1.5rem;
-  white-space: pre; }
+  white-space: pre-wrap; }
 
 
 /* Tables


### PR DESCRIPTION
Fix the output code to wrap lines.    Currently the output looks like this:

<img width="903" alt="image" src="https://user-images.githubusercontent.com/58999374/150165052-c6130902-2a24-47bc-bc14-a5d241def61d.png">

PR changes it to this:

<img width="783" alt="image" src="https://user-images.githubusercontent.com/58999374/150165203-c00372e8-1f8f-4e9a-b938-91909c71b988.png">

Exceedingly minor change.
